### PR TITLE
Add a custom baseline config tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,11 @@ the results directory and optionally specify a filename for JSON data to be
 saved to. For more information, refer to the
 [parsing document](docs/parsing.md).
 
+## Comparing baselines
+The results parser can be extended to compare results against an existing
+baseline, either built-in to Bobber or passed in as a YAML file. For more
+information, refer to the [baselines document](docs/baselines.md).
+
 # Design Rationale
 
 ## Submodules

--- a/bobber/bobber.py
+++ b/bobber/bobber.py
@@ -167,8 +167,14 @@ def parse_args(version: str) -> Namespace:
                        'was used for all tests.', action='store_true')
     parse.add_argument('--compare-baseline', help='Compare the values produced'
                        ' by a test run against a pre-defined baseline to '
-                       'verify performance meets an acceptable threshold.',
+                       'verify performance meets an acceptable threshold. '
+                       'This command is ignored if the --custom-baseline flag '
+                       'is used.',
                        choices=BASELINES)
+    parse.add_argument('--custom-baseline', help='Compare against a custom '
+                       'baseline to verify performance meets an acceptable '
+                       'threshold. This command overrides the '
+                       '--compare-baseline flag.', type=str)
     parse.add_argument('--verbose', help='Display text-based information for '
                        'each system count in addition to the table.',
                        action='store_true')
@@ -310,7 +316,8 @@ def execute_command(args: Namespace, version: str) -> NoReturn:
         A ``string`` of the Bobber version.
     """
     if args.command == PARSE_RESULTS:
-        parse_results.main(args.log_path, args.compare_baseline, args.verbose)
+        parse_results.main(args.log_path, args.compare_baseline,
+                           args.custom_baseline, args.verbose)
     elif args.command == BUILD:
         bobber.lib.docker.build(version)
     elif args.command == EXPORT:

--- a/bobber/bobber.py
+++ b/bobber/bobber.py
@@ -175,6 +175,16 @@ def parse_args(version: str) -> Namespace:
                        'baseline to verify performance meets an acceptable '
                        'threshold. This command overrides the '
                        '--compare-baseline flag.', type=str)
+    parse.add_argument('--baseline-tolerance', help='The percentage of '
+                       'tolerance to include while comparing results against '
+                       'a baseline. For example, if the desire is to allow '
+                       'results to be within 5%% of the baseline and still '
+                       'pass, enter "5" for the tolerance. This will only '
+                       'measure tolerance below the result and will not punish'
+                       ' if numbers are higher than the baseline above the '
+                       'tolerance level. This value is ignored if not running '
+                       'the baseline comparison. Defaults to 0 tolerance.',
+                       type=int, default=0)
     parse.add_argument('--verbose', help='Display text-based information for '
                        'each system count in addition to the table.',
                        action='store_true')
@@ -317,7 +327,8 @@ def execute_command(args: Namespace, version: str) -> NoReturn:
     """
     if args.command == PARSE_RESULTS:
         parse_results.main(args.log_path, args.compare_baseline,
-                           args.custom_baseline, args.verbose)
+                           args.custom_baseline, args.baseline_tolerance,
+                           args.verbose)
     elif args.command == BUILD:
         bobber.lib.docker.build(version)
     elif args.command == EXPORT:

--- a/bobber/lib/analysis/compare_baseline.py
+++ b/bobber/lib/analysis/compare_baseline.py
@@ -2,6 +2,7 @@
 import sys
 from bobber.lib.constants import BASELINES
 from bobber.lib.analysis.common import bcolors
+from bobber.lib.system.file_handler import read_yaml
 
 
 # Map the dicitonary keys in the baseline to human-readable names.
@@ -97,15 +98,21 @@ def evaluate_test(baseline, results, system_count):
         sys.exit(1)
 
 
-def compare_baseline(results, baseline):
+def compare_baseline(results, baseline, custom=False):
     print('=' * 80)
     print('Baseline assessment')
-    print(f'Comparing against "{baseline}"')
-    baseline = BASELINES[baseline]
+    if custom:
+        print('Comparing against a custom config')
+        baseline = read_yaml(baseline)
+    else:
+        print(f'Comparing against "{baseline}"')
+        baseline = BASELINES[baseline]
 
     for system_count, baseline_results in baseline['systems'].items():
+        print('=' * 80)
+        print(f' {system_count} System(s)')
         evaluate_test(baseline_results,
-                      results['systems'][system_count],
+                      results['systems'][str(system_count)],
                       system_count)
 
     print('=' * 80)

--- a/bobber/lib/analysis/parse_results.py
+++ b/bobber/lib/analysis/parse_results.py
@@ -107,7 +107,7 @@ def save_json(final_dictionary_output, filename):
         print(f'JSON data saved to {filename}')
 
 
-def main(directory, baseline=None, verbose=False,
+def main(directory, baseline=None, custom_baseline=None, verbose=False,
          override_version_check=False, json_filename=None):
     final_dictionary_output = {'systems': {}}
 
@@ -154,5 +154,7 @@ def main(directory, baseline=None, verbose=False,
     display_table(final_dictionary_output)
     save_json(final_dictionary_output, json_filename)
 
-    if baseline:
+    if custom_baseline:
+        compare_baseline(final_dictionary_output, custom_baseline, custom=True)
+    elif baseline:
         compare_baseline(final_dictionary_output, baseline)

--- a/bobber/lib/analysis/parse_results.py
+++ b/bobber/lib/analysis/parse_results.py
@@ -107,8 +107,8 @@ def save_json(final_dictionary_output, filename):
         print(f'JSON data saved to {filename}')
 
 
-def main(directory, baseline=None, custom_baseline=None, verbose=False,
-         override_version_check=False, json_filename=None):
+def main(directory, baseline=None, custom_baseline=None, tolerance=0,
+         verbose=False, override_version_check=False, json_filename=None):
     final_dictionary_output = {'systems': {}}
 
     log_files = get_files(directory)
@@ -155,6 +155,7 @@ def main(directory, baseline=None, custom_baseline=None, verbose=False,
     save_json(final_dictionary_output, json_filename)
 
     if custom_baseline:
-        compare_baseline(final_dictionary_output, custom_baseline, custom=True)
+        compare_baseline(final_dictionary_output, custom_baseline, tolerance,
+                         custom=True)
     elif baseline:
-        compare_baseline(final_dictionary_output, baseline)
+        compare_baseline(final_dictionary_output, baseline, tolerance)

--- a/bobber/lib/system/file_handler.py
+++ b/bobber/lib/system/file_handler.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 import os
+import yaml
 from typing import NoReturn
 
 
@@ -29,3 +30,21 @@ def update_log(logfile: str, contents: str) -> NoReturn:
     """
     with open(logfile, 'a') as log:
         log.write(contents)
+
+
+def read_yaml(filename: str) -> dict:
+    """
+    Read a YAML file and return the contents.
+
+    Parameters
+    ----------
+    filename : string
+        A ``string`` of the full file path to read.
+
+    Returns
+    -------
+    dict
+        Returns a ``dict`` representing the entire contents of the file.
+    """
+    with open(filename, 'r') as handler:
+        return yaml.safe_load(handler)

--- a/docs/baselines.md
+++ b/docs/baselines.md
@@ -68,6 +68,20 @@ the YAML file location and log directory, if applicable:
 bobber parse-results --custom-baseline custom_baseline_file.yaml results_log/
 ```
 
+### Adding a tolerance
+Both of the baseline methods above allow a custom tolerance to be specified to
+give some wiggle-room in the results. Pass a percentage amount to allow below
+the baseline.
+
+Take for example a baseline that expects 10 GB/s from reads using FIO. If the
+test results yield 9.8 GB/s, this will be marked as a FAIL. However, if the
+tolerance is 5%, this will instead be marked as a PASS as 9.8 GB/s is within 5%
+of the expected value of 10 GB/s.
+
+To add a tolerance, add the `--baseline-tolerance` flag to either of the
+commands above. The default tolerance is 0% if not specified, meaning the test
+will fail if it is exactly at or below the baseline value.
+
 ## Baseline results output
 Regardless of which baseline method from above is chosen, the results will
 compare the performance from the requested results file with the baseline of

--- a/docs/baselines.md
+++ b/docs/baselines.md
@@ -1,0 +1,152 @@
+# Baselines
+The results parser included with Bobber is able to compare results against a
+pre-defined baseline or a custom baseline passed in as a YAML file. By comparing
+results against a baseline, it is possible to easily check if a round of tests
+meets the expected performance level or if any tests are underperforming. This
+is useful to verify new systems are performing as expected or to view if any
+changes to the hardware or software affect stability.
+
+## Running the baseline comparison
+There are two main paths to compare baselines in Bobber, either by using a
+built-in baseline config or using a custom file.
+
+### Using built-in baselines
+To compare against a built-in baseline, use the `--compare-baseline` flag with
+the `parse-results` command. To list the possible choices, pass the `--help`
+flag as below. The choices are listed in the curly brackets (`{}`):
+
+```
+bobber parse-results --help
+...
+  --compare-baseline {single-dgx-station-baseline}
+                        Compare the values produced by a test run against a pre-defined baseline to verify performance meets an acceptable threshold.
+```
+
+To run the comparison against existing results, run the following while updating
+the baseline and log directory, if applicable.
+
+```
+bobber parse-results --compare-baseline single-dgx-station-baseline results_logs/
+```
+
+### Using custom baselines
+To use a custom baseline, a YAML file needs to be created which specifies the
+expected performance for every test. A [sample file](sample_baseline.yaml) has
+been created as a guide. Every custom baseline file must have the following
+structure:
+
+```
+systems:  # This should always be the first line
+    1:  # This designates all results in the sub-block are specific to a single compute node
+        bandwidth:  # This section is for the FIO bandwidth results in bytes/second
+            read: 1200000000  # The FIO bandwidth read results in bytes/second
+            write: 1000000000  # The FIO bandwidth write results in bytes/second
+        iops:  # This section is for the FIO IOPS results in ops/second
+            read: 100000  # The FIO IOPS read speed in ops/second
+            write: 100000  # The FIO IOPS write speed in ops/second
+        nccl:  # The maximum bus bandwidth in GB/s for NCCL
+            max_bus_bw: 230  # The maximum bus bandwidth in GB/s for NCCL
+        dali:  # The average speed in images/second from DALI tests
+            800x600 standard jpg: 2000  # The speed in images/second for 800x600 standard JPG images in DALI
+            3840x2160 standard jpg: 300  # The speed in images/second for 4K standard JPG images in DALI
+            800x600 tfrecord: 2000  # The speed in images/second for 800x600 TFRecords in DALI
+            3840x2160 tfrecord: 300  # The speed in images/second for 4K TFRecords in DALI
+    2: # Continue the same pattern as above for results specific to two compute nodes, if applicable
+    ...
+```
+
+The custom results parser will only compare against the system counts that are
+provided in the YAML file, meaning if only results for 8 compute nodes are
+included in the YAML file, only those results will be compared. As many or as
+few system counts as desired can be added to the YAML file to more extensively
+compare results at all levels.
+
+After saving the YAML file locally, run the comparison as follows while updating
+the YAML file location and log directory, if applicable:
+
+```
+bobber parse-results --custom-baseline custom_baseline_file.yaml results_log/
+```
+
+## Baseline results output
+Regardless of which baseline method from above is chosen, the results will
+compare the performance from the requested results file with the baseline of
+choice. The comparison does a simple PASS/FAIL for every result depending on
+whether it surpasses performance or not. If at least one result does not meet
+performance expectations, the comparison will be marked as failed.
+
+Example of results that pass every threshold:
+
+```
+bobber parse-results --compare-baseline single-dgx-station-baseline log_files/
+
+...
+
+================================================================================
+Baseline assessment
+Comparing against "single-dgx-station-baseline"
+================================================================================
+ 1 System(s)
+--------------------------------------------------------------------------------
+  FIO Bandwidth Read (GB/s)
+    Expected: 1.2, Got: 1.595, Result: PASS
+  FIO Bandwidth Write (GB/s)
+    Expected: 1.0, Got: 1.232, Result: PASS
+--------------------------------------------------------------------------------
+  FIO IOPS Read (k IOPS)
+    Expected: 100.0, Got: 136.5, Result: PASS
+  FIO IOPS Write (k IOPS)
+    Expected: 100.0, Got: 135.0, Result: PASS
+--------------------------------------------------------------------------------
+  NCCL Max Bus Bandwidth (GB/s)
+    Expected: 70, Got: 79.86500000000001, Result: PASS
+--------------------------------------------------------------------------------
+  DALI 800x600 standard jpg (images/second)
+    Expected: 2000, Got: 2694.595, Result: PASS
+  DALI 3840x2160 standard jpg (images/second)
+    Expected: 300, Got: 430.854, Result: PASS
+  DALI 800x600 tfrecord (images/second)
+    Expected: 2000, Got: 2665.653, Result: PASS
+  DALI 3840x2160 tfrecord (images/second)
+    Expected: 300, Got: 376.862, Result: PASS
+================================================================================
+```
+
+Example of results that fail one or more thresholds:
+
+```
+bobber parse-results --custom-baseline sample_baseline.yaml log_files/
+
+...
+
+================================================================================
+Baseline assessment
+Comparing against a custom config
+================================================================================
+ 1 System(s)
+--------------------------------------------------------------------------------
+  FIO Bandwidth Read (GB/s)
+    Expected: 7.0, Got: 1.595, Result: FAIL
+  FIO Bandwidth Write (GB/s)
+    Expected: 3.0, Got: 1.232, Result: FAIL
+--------------------------------------------------------------------------------
+  FIO IOPS Read (k IOPS)
+    Expected: 300.0, Got: 136.5, Result: FAIL
+  FIO IOPS Write (k IOPS)
+    Expected: 200.0, Got: 135.0, Result: FAIL
+--------------------------------------------------------------------------------
+  NCCL Max Bus Bandwidth (GB/s)
+    Expected: 230, Got: 79.86500000000001, Result: FAIL
+--------------------------------------------------------------------------------
+  DALI 800x600 standard jpg (images/second)
+    Expected: 2000, Got: 2694.595, Result: PASS
+  DALI 3840x2160 standard jpg (images/second)
+    Expected: 300, Got: 430.854, Result: PASS
+  DALI 800x600 tfrecord (images/second)
+    Expected: 2000, Got: 2665.653, Result: PASS
+  DALI 3840x2160 tfrecord (images/second)
+    Expected: 300, Got: 376.862, Result: PASS
+--------------------------------------------------------------------------------
+5 tests did not meet the suggested criteria!
+See results above for failed tests and verify setup.
+```

--- a/docs/sample_baseline.yaml
+++ b/docs/sample_baseline.yaml
@@ -1,0 +1,37 @@
+systems:
+    1:
+        bandwidth:
+            # FIO BW speed in bytes/second
+            read: 1200000000
+            write: 1000000000
+        iops:
+            # FIO IOPS speed in ops/second
+            read: 100000
+            write: 100000
+        nccl:
+            # NCCL maximum bus bandwidth in GB/s
+            max_bus_bw: 230
+        dali:
+            # DALI average speed in images/second
+            800x600 standard jpg: 2000
+            3840x2160 standard jpg: 300
+            800x600 tfrecord: 2000
+            3840x2160 tfrecord: 300
+    2:
+        bandwidth:
+            # FIO BW speed in bytes/second
+            read: 2400000000
+            write: 2000000000
+        iops:
+            # FIO IOPS speed in ops/second
+            read: 200000
+            write: 200000
+        nccl:
+            # NCCL maximum bus bandwidth in GB/s
+            max_bus_bw: 185
+        dali:
+            # DALI average speed in images/second
+            800x600 standard jpg: 4000
+            3840x2160 standard jpg: 600
+            800x600 tfrecord: 4000
+            3840x2160 tfrecord: 600

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ docker==4.3.1
 idna==2.10
 numpy==1.19.5
 pycodestyle==2.6.0
+PyYAML==5.4.1
 requests==2.24.0
 six==1.15.0
 tabulate==0.8.7

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ workload performance''',
     install_requires=[
         'docker >= 4.3.1',
         'numpy >= 1.9.5',
+        'pyyaml >= 5.4.0',
         'tabulate >= 0.8.7'
     ]
 )


### PR DESCRIPTION
Users should be able to create a custom baseline configuration which can be used to compare test results against a specific baseline to verify performance. This provides an easy PASS/FAIL system indicating whether a cluster has been properly configured or not. Additionally, a configurable tolerance should added to accept values within an acceptable range.

Closes #8 

Signed-Off-By: Robert Clark <roclark@nvidia.com>