### PR TITLE
Remove unused commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,26 +75,23 @@ usage: Bobber Version: 6.0.0 [-h] command ...
 
 positional arguments:
   command
-    run-all       Run all tests
-    run-stress    Run NVSM stress test only
-    run-dali      Run DALI tests only
-    run-nccl      Run NCCL tests only
-    run-networking
-                  Run networking tests only
-    run-stg-bw    Run storage bandwdith tests only
-    run-stg-iops  Run storage IOPS tests only
-    run-stg-meta  Run storage metadata tests only
-    run-stg-fill  Run storage fill workload - intended to run only from a
-                  single client, will ignore --hosts argument
-    export        Export the container for multisystem tests
+    run-all      Run all tests
+    run-dali     Run DALI tests only
+    run-nccl     Run NCCL tests only
+    run-stg-bw   Run storage bandwdith tests only
+    run-stg-iops
+                 Run storage IOPS tests only
+    run-stg-meta
+                 Run storage metadata tests only
+    export       Export the container for multisystem tests
     parse-results
-                  Parse and display resultsfrom the log files
-    build         Build the container
-    cast          Start the container
-    load          Load a container from a local binary
+                 Parse and display resultsfrom the log files
+    build        Build the container
+    cast         Start the container
+    load         Load a container from a local binary
 
 optional arguments:
-  -h, --help      show this help message and exit
+  -h, --help     show this help message and exit
 ```
 
 ## Build Bobber container (includes OSU Tests, NCCL Tests, fio, mdtest, DALI RN50 Pipeline, and the base NGC TensorFlow container)

--- a/bobber/bobber.py
+++ b/bobber/bobber.py
@@ -15,14 +15,11 @@ from bobber.lib.constants import (
     LOAD,
     PARSE_RESULTS,
     RUN_ALL,
-    RUN_STRESS,
     RUN_DALI,
     RUN_NCCL,
-    RUN_NETWORKING,
     RUN_STG_BW,
     RUN_STG_IOPS,
     RUN_STG_META,
-    RUN_STG_FILL,
     SYSTEMS
 )
 from bobber.lib.analysis import parse_results
@@ -132,13 +129,9 @@ def parse_args(version: str) -> Namespace:
     # Create the test initiation commands with the general options above
     commands.add_parser(RUN_ALL, help='Run all tests',
                         parents=[commands_parent])
-    commands.add_parser(RUN_STRESS, help='Run NVSM stress test only',
-                        parents=[commands_parent])
     commands.add_parser(RUN_DALI, help='Run DALI tests only',
                         parents=[commands_parent])
     commands.add_parser(RUN_NCCL, help='Run NCCL tests only',
-                        parents=[commands_parent])
-    commands.add_parser(RUN_NETWORKING, help='Run networking tests only',
                         parents=[commands_parent])
     commands.add_parser(RUN_STG_BW, help='Run storage bandwdith tests only',
                         parents=[commands_parent])
@@ -146,9 +139,6 @@ def parse_args(version: str) -> Namespace:
                         parents=[commands_parent])
     commands.add_parser(RUN_STG_META, help='Run storage metadata tests only',
                         parents=[commands_parent])
-    commands.add_parser(RUN_STG_FILL, help='Run storage fill workload - '
-                        'intended to run only from a single client, will '
-                        'ignore --hosts argument')
 
     # Options specific to exporting the containers
     export = commands.add_parser(EXPORT, help='Export the container for '

--- a/bobber/lib/constants.py
+++ b/bobber/lib/constants.py
@@ -5,14 +5,11 @@ CAST = 'cast'
 LOAD = 'load'
 PARSE_RESULTS = 'parse-results'
 RUN_ALL = 'run-all'
-RUN_STRESS = 'run-stress'
 RUN_DALI = 'run-dali'
 RUN_NCCL = 'run-nccl'
-RUN_NETWORKING = 'run-networking'
 RUN_STG_BW = 'run-stg-bw'
 RUN_STG_IOPS = 'run-stg-iops'
 RUN_STG_META = 'run-stg-meta'
-RUN_STG_FILL = 'run-stg-fill'
 
 DGX_A100_SINGLE = {
     'gpus': 8,

--- a/bobber/lib/tests/run_tests.py
+++ b/bobber/lib/tests/run_tests.py
@@ -5,9 +5,7 @@ from bobber.lib.constants import (
     RUN_ALL,
     RUN_DALI,
     RUN_NCCL,
-    RUN_NETWORKING,
     RUN_STG_BW,
-    RUN_STG_FILL,
     RUN_STG_IOPS,
     RUN_STG_META
 )


### PR DESCRIPTION
A few commands were included in the usage but didn't have any actual functionality. They should be removed for now while the functionality does not yet exist, but can be added back later once supported.

Closes #14

Signed-Off-By: Robert Clark <roclark@nvidia.com>