### PR TITLE
Handle situations where no logs are found

### DIFF
--- a/bobber/lib/analysis/parse_results.py
+++ b/bobber/lib/analysis/parse_results.py
@@ -112,6 +112,11 @@ def main(directory, baseline=None, verbose=False,
     final_dictionary_output = {'systems': {}}
 
     log_files = get_files(directory)
+    if len(log_files) < 1:
+        print('No log files found. Please specify a directory containing '
+              'valid logs.')
+        print('Exiting...')
+        sys.exit(1)
     bobber_version = check_bobber_version(log_files,
                                           override_version_check)
     bw_results = parse_fio_bw(log_files)


### PR DESCRIPTION
If a user passes a directory without any log files, a nasty and vague error is thrown. Catching the error makes it much easier for users to determine the next course of action to resolve the issue.

Fixes #19 

Signed-Off-By: Robert Clark <roclark@nvidia.com>