### PR TITLE
Remove memory restriction in containers

### DIFF
--- a/bobber/lib/docker/management.py
+++ b/bobber/lib/docker/management.py
@@ -100,7 +100,6 @@ class DockerManager:
             detach=True,
             auto_remove=True,
             ipc_mode='host',
-            mem_limit='40g',
             name='bobber',
             network_mode='host',
             privileged=True,


### PR DESCRIPTION
The memory constraint proved to have adverse effects while running fio read IOPS tests for high-thread counts, such as the default of 200, on dual-socket systems. To prevent issues with the tests moving forward, the restriction is being removed to allow the container to use as much memory as required.

DALI will need to be revisited to see how this affects results and if the test needs to be further updated.

Fixes #20 

Signed-Off-By: Robert Clark <roclark@nvidia.com>