### PR TITLE
Update wheel metadata information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,7 @@ with open('README.md', 'r') as f:
 setup(
     name='nvidia-bobber',
     version=__version__,
-    description='''Containerized testing of system components that impact AI
-workload performance''',
+    description='Containerized testing of system components that impact AI workload performance',
     long_description=long_description,
     packages=['bobber',
               'bobber/lib',


### PR DESCRIPTION
The `setup.py` description tag being multi-line messed with the wheel metadata.

Signed-Off-By: Robert Clark <roclark@nvidia.com>