### PR TITLE
Add documentation on common exit statuses

### DIFF
--- a/bobber/lib/analysis/compare_baseline.py
+++ b/bobber/lib/analysis/compare_baseline.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 import sys
 from bobber.lib.constants import BASELINES
+from bobber.lib.exit_codes import BASELINE_FAILURE
 from bobber.lib.analysis.common import bcolors
 from bobber.lib.system.file_handler import read_yaml
 
@@ -101,7 +102,7 @@ def evaluate_test(baseline, results, system_count, tolerance):
         print('See results above for failed tests and verify setup.')
         # Throw a non-zero exit status so any tools that read codes will catch
         # that the baseline was not met.
-        sys.exit(1)
+        sys.exit(BASELINE_FAILURE)
 
 
 def compare_baseline(results, baseline, tolerance, custom=False):

--- a/bobber/lib/analysis/parse_results.py
+++ b/bobber/lib/analysis/parse_results.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from datetime import datetime
 from glob import glob
 from os.path import join
+from bobber.lib.exit_codes import MISSING_LOG_FILES, SUCCESS
 from bobber.lib.analysis.aggregate_results import AggregateResults
 from bobber.lib.analysis.common import (check_bobber_version,
                                         divide_logs_by_systems)
@@ -86,7 +87,7 @@ def verify_template(template):
             response = input(prompt)
         except KeyboardInterrupt:
             print('Keyboard interrupt - exiting...')
-            sys.exit()
+            sys.exit(SUCCESS)
         if response.lower().strip() == 'y':
             break
         elif response.lower().strip() == 'n':
@@ -94,7 +95,7 @@ def verify_template(template):
             print('Please update the template file located in '
                   'analysis/template.yaml and run again.')
             print('Exiting...')
-            sys.exit()
+            sys.exit(SUCCESS)
 
 
 def save_json(final_dictionary_output, filename):
@@ -116,7 +117,7 @@ def main(directory, baseline=None, custom_baseline=None, tolerance=0,
         print('No log files found. Please specify a directory containing '
               'valid logs.')
         print('Exiting...')
-        sys.exit(1)
+        sys.exit(MISSING_LOG_FILES)
     bobber_version = check_bobber_version(log_files,
                                           override_version_check)
     bw_results = parse_fio_bw(log_files)

--- a/bobber/lib/docker/management.py
+++ b/bobber/lib/docker/management.py
@@ -2,6 +2,7 @@
 import docker
 import os
 import sys
+from bobber.lib.exit_codes import DOCKER_BUILD_FAILURE
 from bobber.lib.system.file_handler import update_log
 from typing import NoReturn, Optional
 
@@ -170,7 +171,7 @@ class DockerManager:
             if 'error' in line.keys():
                 print(line['error'].rstrip())
                 print(f'{tag} build failed. See error above.')
-                sys.exit(-1)
+                sys.exit(DOCKER_BUILD_FAILURE)
             if 'stream' in line.keys() and line['stream'].strip() != '':
                 print(line['stream'].rstrip())
         print(f'{tag} successfully built')

--- a/bobber/lib/exit_codes.py
+++ b/bobber/lib/exit_codes.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# This file contains a list of exit codes for debugging
+SUCCESS = 0  # Successful termination
+BASELINE_FAILURE = -10  # Performance did not meet criteria
+MISSING_LOG_FILES = -20  # Parsing directory with no logs
+DOCKER_BUILD_FAILURE = -30  # Failure building Docker image

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,47 @@
+# Troubleshooting
+Things don't always go as planned. This guide provides some steps to
+troubleshoot Bobber when it doesn't work as expected.
+
+## General troubleshooting
+The first item to check when something goes wrong is the Docker image and
+containers across the cluster. On all hosts, verify the Docker image is built
+and matches the version of the Bobber wheel. Check the Bobber version with:
+
+```
+$ bobber --version
+6.1.1
+```
+
+The version number is listed in the first line. Check the Bobber image is built
+and matches the version above with:
+
+```
+$ docker images | grep nvidia/bobber
+nvidia/bobber   6.1.1   c697a75ee482    36 minutes ago  12.4GB
+```
+
+If the above command does not contain output or the second column (`6.1.1` in
+the example) does not match the version of Bobber from the first step, the image
+needs to be built. Run `bobber build` to build the image and verify using the
+steps above once complete.
+
+Before any tests can be run, the container needs to be launched on all nodes.
+This can be verified with:
+
+```
+$ docker ps | grep bobber
+1ab2b10f8eb1    nvidia/bobber:6.1.1 "/usr/local/bin/nvid..."    4 days ago  Up 4 days   bobber
+```
+
+If the above command does not contain output, the container needs to be launched
+using the `bobber cast /path/to/storage` command.
+
+## Exit codes
+When the application terminates after a handled issue, various exit codes may be
+thrown depending on the situation. The following list provides extra context on
+these codes:
+
+  * `0`: Exit Success - The application terminated successfully.
+  * `-10`: Baseline Failure - This is thrown while comparing results from a test run against a baseline (either one of the defaults or a custom baseline) using the `bobber parse-results --compare-baseline ...` or `bobber parse-results --custom-baseline ...` command. If at least one result doesn't exceed the baseline performance, it will be marked as a failure. Check the output of the command for a list of the results that don't exceed baseline performance and verify connectivity and configuration.
+  * `-20`: Missing Log Files - Thrown while attempting to parse results while specifying a directory that does not contain valid log files. Verify the directory being parsed contains log files with data.
+  * `-30`: Docker Build Failure - Thrown while trying to build the Bobber image with `bobber build`. Look at the output from the command to see if there are any specific issues while building. This is commonly seen when networking on host and/or Docker levels are down.


### PR DESCRIPTION
Potential non-zero exit status need to be documented properly to give users an idea of what went wrong and how to resolve any issues. A dedicated troubleshooting guide is added to compliment this work.

Fixes #9 

Signed-Off-By: Robert Clark <roclark@nvidia.com>