### PR TITLE
Add --version flag

### DIFF
--- a/bobber/bobber.py
+++ b/bobber/bobber.py
@@ -50,6 +50,7 @@ def parse_args(version: str) -> Namespace:
         the application during runtime.
     """
     parser = ArgumentParser(f'Bobber Version: {version}')
+    parser.add_argument('--version', action='version', version=__version__)
     # Required positional command subparser which should be specified first
     commands = parser.add_subparsers(dest='command', metavar='command')
     commands_parent = ArgumentParser(add_help=False)


### PR DESCRIPTION
Add the `--version` flag to the default usage to easily display the version of the installed application.

Closes #26 

Signed-Off-By: Robert Clark <roclark@nvidia.com>