### PR TITLE
Fix issue running all tests with latest release

### DIFF
--- a/bobber/lib/tests/run_tests.py
+++ b/bobber/lib/tests/run_tests.py
@@ -238,8 +238,6 @@ def kickoff_test(args: Namespace, bobber_version: str, iteration: int,
         run_stg_iops(args, bobber_version, iteration, hosts)
     elif args.command == RUN_STG_META:
         run_stg_meta(args, bobber_version, iteration, hosts)
-    elif args.command == RUN_STG_FILL:
-        run_stg_fill(args, bobber_version, iteration, hosts)
     elif args.command == RUN_ALL:
         run_nccl(args, bobber_version, iteration, hosts)
         run_stg_meta(args, bobber_version, iteration, hosts)


### PR DESCRIPTION
The latest release introduced an issue while attempting to run all tests where a stacktrace would be thrown attempting to handle a test that no longer exists.

Signed-Off-By: Robert Clark <roclark@nvidia.com>