### PR TITLE
Fix metadata parsing with warnings in logs

### DIFF
--- a/bobber/lib/analysis/meta.py
+++ b/bobber/lib/analysis/meta.py
@@ -29,7 +29,8 @@ def pull_stats(summary):
 
 
 def parse_summary(log_contents):
-    summary = re.findall('---------.*-- finished', log_contents, re.DOTALL)
+    summary = re.findall('---------                      .*-- finished',
+                         log_contents, re.DOTALL)
     if len(summary) == 0:
         return None
     # `summary` is a single-element list where the element is a list of all of


### PR DESCRIPTION
Some corner cases exist where a warning is raised in the mdtest logs but the tests are still able to complete. This throws the parser off as it would attempt to pull the warning message in with the operation summary and throw an error that it can't pull values from the warning message.

Signed-Off-By: Robert Clark <roclark@nvidia.com>