### PR TITLE
Allow pauses between tests

### DIFF
--- a/bobber/bobber.py
+++ b/bobber/bobber.py
@@ -158,6 +158,10 @@ def parse_args(version: str) -> Namespace:
                                  'supported - stg-bw and stg-iops). If '
                                  'providing more than one flag, wrap entire '
                                  'set in quotes')
+    commands_parent.add_argument('--pause', help='Pause between tests for N '
+                                 'seconds to ensure any activity is finished '
+                                 'before the next test begins. Defaults to 0 '
+                                 '(no pause).', type=int, default=0)
 
     # Create the test initiation commands with the general options above
     commands.add_parser(RUN_ALL, help='Run all tests',

--- a/bobber/lib/tests/run_tests.py
+++ b/bobber/lib/tests/run_tests.py
@@ -10,6 +10,7 @@ from bobber.lib.constants import (
     RUN_STG_META
 )
 from bobber.lib.docker import manager
+from time import sleep
 from typing import NoReturn
 
 
@@ -52,6 +53,9 @@ def run_dali(args: Namespace, bobber_version: str, iteration: int,
                     environment=environment,
                     log_file=dali_log)
 
+    if args.pause > 0:
+        sleep(args.pause)
+
 
 def run_stg_bw(args: Namespace, bobber_version: str, iteration: int,
                hosts: str) -> NoReturn:
@@ -91,6 +95,9 @@ def run_stg_bw(args: Namespace, bobber_version: str, iteration: int,
     manager.execute('tests/fio_multi.sh',
                     environment=environment,
                     log_file=stg_bw_log)
+
+    if args.pause > 0:
+        sleep(args.pause)
 
 
 def run_stg_iops(args: Namespace, bobber_version: str, iteration: int,
@@ -132,6 +139,9 @@ def run_stg_iops(args: Namespace, bobber_version: str, iteration: int,
                     environment=environment,
                     log_file=stg_iops_log)
 
+    if args.pause > 0:
+        sleep(args.pause)
+
 
 def run_stg_meta(args: Namespace, bobber_version: str, iteration: int,
                  hosts: str) -> NoReturn:
@@ -165,6 +175,9 @@ def run_stg_meta(args: Namespace, bobber_version: str, iteration: int,
     manager.execute('tests/mdtest_multi.sh',
                     environment=environment,
                     log_file=stg_meta_log)
+
+    if args.pause > 0:
+        sleep(args.pause)
 
 
 def run_nccl(args: Namespace, bobber_version: str, iteration: int,
@@ -207,6 +220,9 @@ def run_nccl(args: Namespace, bobber_version: str, iteration: int,
     manager.execute('tests/nccl_multi.sh',
                     environment=environment,
                     log_file=nccl_log)
+
+    if args.pause > 0:
+        sleep(args.pause)
 
 
 def kickoff_test(args: Namespace, bobber_version: str, iteration: int,


### PR DESCRIPTION
Some tests require additional cleanup time for various filesystems which can impact performance if another test is running during cleanup. Adding a flag to allow the framework to pause for N-seconds between tests allows the cleanup additional time to complete before follow-up rounds.

Closes #40

Signed-Off-By: Robert Clark <roclark@nvidia.com>