### PR TITLE
Upgrade Imageinary version

### DIFF
--- a/bobber/lib/docker/Dockerfile
+++ b/bobber/lib/docker/Dockerfile
@@ -80,7 +80,7 @@ RUN wget --no-check-certificate https://mvapich.cse.ohio-state.edu/download/mvap
 
 RUN python3 -m pip install nvidia-pyindex && \
     python3 -m pip install \
-        nvidia-imageinary['mxnet']==1.0.3
+        nvidia-imageinary['mxnet']>=1.1.2
 
 RUN git clone https://github.com/jyvet/io-500-dev && \
 	cd io-500-dev && \

--- a/bobber/test_scripts/dali_multi.sh
+++ b/bobber/test_scripts/dali_multi.sh
@@ -39,11 +39,11 @@ mkdir -p /mnt/fs_under_test/imageinary_data/800x600/tfrecord_pipeline
 mkdir -p /mnt/fs_under_test/imageinary_data/3840x2160/tfrecord_pipeline.idx
 mkdir -p /mnt/fs_under_test/imageinary_data/800x600/tfrecord_pipeline.idx
 
-imagine create-images --path /mnt/fs_under_test/imageinary_data/3840x2160/file_read_pipeline_images/images --name 4k_image_ --width 3840 --height 2160 --count $(($GPUS*1000)) --image_format jpg --size
-imagine create-images --path /mnt/fs_under_test/imageinary_data/800x600/file_read_pipeline_images/images --name small_image_ --width 800 --height 600 --count $(($GPUS*1000)) --image_format jpg --size
+imagine create-images --width 3840 --height 2160 --count $(($GPUS*1000)) --size /mnt/fs_under_test/imageinary_data/3840x2160/file_read_pipeline_images/images 4k_image_ jpg
+imagine create-images --width 800 --height 600 --count $(($GPUS*1000)) --size /mnt/fs_under_test/imageinary_data/800x600/file_read_pipeline_images/images small_image_ jpg
 
-imagine create-tfrecords --source_path /mnt/fs_under_test/imageinary_data/3840x2160/file_read_pipeline_images/images --dest_path /mnt/fs_under_test/imageinary_data/3840x2160/tfrecord_pipeline --name tfrecord- --img_per_file 1000
-imagine create-tfrecords --source_path /mnt/fs_under_test/imageinary_data/800x600/file_read_pipeline_images/images --dest_path /mnt/fs_under_test/imageinary_data/800x600/tfrecord_pipeline --name tfrecord- --img_per_file 1000
+imagine create-tfrecords --img-per-file 1000 /mnt/fs_under_test/imageinary_data/3840x2160/file_read_pipeline_images/images /mnt/fs_under_test/imageinary_data/3840x2160/tfrecord_pipeline tfrecord-
+imagine create-tfrecords --img-per-file 1000 /mnt/fs_under_test/imageinary_data/800x600/file_read_pipeline_images/images /mnt/fs_under_test/imageinary_data/800x600/tfrecord_pipeline tfrecord-
 
 for i in $(seq 0 $GPUS_ZERO_BASE); do /dali/tools/tfrecord2idx /mnt/fs_under_test/imageinary_data/3840x2160/tfrecord_pipeline/tfrecord-$i /mnt/fs_under_test/imageinary_data/3840x2160/tfrecord_pipeline.idx/tfrecord-$i; done
 for i in $(seq 0 $GPUS_ZERO_BASE); do /dali/tools/tfrecord2idx /mnt/fs_under_test/imageinary_data/800x600/tfrecord_pipeline/tfrecord-$i /mnt/fs_under_test/imageinary_data/800x600/tfrecord_pipeline.idx/tfrecord-$i; done


### PR DESCRIPTION
The latest version of Imageinary has a new CLI which isn't compatible with the way it is called in the DALI tests at present.

Closes #50

Signed-Off-By: Robert Clark <roclark@nvidia.com>