### PR TITLE
Optionally save JSON data from parser

### DIFF
--- a/bobber/bobber.py
+++ b/bobber/bobber.py
@@ -187,8 +187,8 @@ def parse_args(version: str) -> Namespace:
     parse.add_argument('log_path', metavar='log-path', help='Path to saved '
                        'logfile location')
     parse.add_argument('--json-filename', help='Specify the filename to use '
-                       'for saving the JSON data. Defaults to the current '
-                       'timestamp.', default=None)
+                       'for saving the JSON data. If not specified, the JSON '
+                       'data will not be saved.', default=None, type=str)
     parse.add_argument('--override-version-check', help='Optionally skip the '
                        'version check to ensure the same version of Bobber '
                        'was used for all tests.', action='store_true')
@@ -355,7 +355,8 @@ def execute_command(args: Namespace, version: str) -> NoReturn:
     if args.command == PARSE_RESULTS:
         parse_results.main(args.log_path, args.compare_baseline,
                            args.custom_baseline, args.baseline_tolerance,
-                           args.verbose)
+                           args.verbose, args.override_version_check,
+                           args.json_filename)
     elif args.command == BUILD:
         bobber.lib.docker.build(version)
     elif args.command == EXPORT:

--- a/bobber/lib/analysis/parse_results.py
+++ b/bobber/lib/analysis/parse_results.py
@@ -2,7 +2,6 @@
 import json
 import sys
 from collections import defaultdict
-from datetime import datetime
 from glob import glob
 from os.path import join
 from bobber.lib.exit_codes import MISSING_LOG_FILES, SUCCESS
@@ -203,7 +202,7 @@ def save_json(final_dictionary_output: dict, filename: str) -> NoReturn:
     Save results to a file.
 
     Save the final JSON data to a file for future reference. If the filename is
-    not specified, create one using the current date and timestamp.
+    not specified, don't save the file.
 
     Parameters
     ----------
@@ -213,9 +212,7 @@ def save_json(final_dictionary_output: dict, filename: str) -> NoReturn:
         A ``string`` of the filename to write the JSON data to.
     """
     if not filename:
-        stamp = datetime.now()
-        filename = (f'bobber_results_{stamp.date()}_{stamp.hour}.'
-                    f'{stamp.minute}.{stamp.second}.json')
+        return
     with open(filename, 'w') as json_file:
         json.dump(final_dictionary_output, json_file)
         print(f'JSON data saved to {filename}')


### PR DESCRIPTION
Currently, the parser automatically saves a JSON file of the results whenever run. This is often not used and leads to added bloat in the local directory. Instead, this should be an opt-in feature where the file is generated only when the user requests it by specifying the `--json-filename` flag.

Fixes #60

Signed-Off-By: Robert Clark <roclark@nvidia.com>