### PR TITLE
Remove nccl-max default from parser

### DIFF
--- a/bobber/bobber.py
+++ b/bobber/bobber.py
@@ -115,7 +115,7 @@ def parse_args(version: str) -> Namespace:
                                  'images', type=int)
     commands_parent.add_argument('--nccl-max', help='Specify the maximum data '
                                  'size to test with NCCL, in Gigabytes '
-                                 '(default is 1 GB)', type=int, default=1)
+                                 '(default is 1 GB)', type=int)
     commands_parent.add_argument('--nccl-ib-hcas', help='Specify the list of '
                                  'interfaces to use for NCCL test multinode '
                                  'communication', default='')


### PR DESCRIPTION
The default value for the `--nccl-max` flag overrode any changes made to the variable via the `--system` flag, causing the value to always be 1 unless explicitly passed to the application. Removing the default allows the values from the `--system` flag to be used unless otherwise specified.

Fixes #63 

Signed-Off-By: Robert Clark <roclark@nvidia.com>